### PR TITLE
Updated RM.md to use /master vs /working

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Docker CLI helper for Triton
 ### Installation
 
 ```bash
-curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/misterbisson/triton-docker/working/triton-docker && chmod +x /usr/local/bin/triton-docker && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install
+curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/misterbisson/triton-docker/master/triton-docker && chmod +x /usr/local/bin/triton-docker && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install
 ```


### PR DESCRIPTION
While testing this,  I noticed the curl was 404'ing.  Changed the raw path to master.  It worked on my mac.

`curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/joyent/triton-docker-cli/master/triton-docker && chmod +x /usr/local/bin/triton-docker && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install`

