### PR TITLE
Execute installation in subshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use of this software also requires [a Triton profile configured in the Triton CL
 In a terminal window, run the following command:
 
 ```bash
-sudo curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/joyent/triton-docker-cli/master/triton-docker && chmod +x /usr/local/bin/triton-docker && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install
+sudo bash -c 'curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/joyent/triton-docker-cli/master/triton-docker && chmod +x /usr/local/bin/triton-docker && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install'
 ```
 
 That command will copy the `triton-docker` shell script from this repo, and link it as `triton-compose` and `triton-docker-install`.


### PR DESCRIPTION
This changes the readme to suggest doing the installation in a subshell, so that the `sudo` apples to all the commands in the chain.

Alternatively to what's in the diff, this could be done with multiple sudo commands:

```bash
sudo curl -o /usr/local/bin/triton-docker https://raw.githubusercontent.com/joyent/triton-docker-cli/master/triton-docker && sudo chmod +x /usr/local/bin/triton-docker && sudo ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-compose && sudo ln -Fs /usr/local/bin/triton-docker /usr/local/bin/triton-docker-install
```

I chose to use the subshell so that it would be easier for sophisticated users to extract the commands and execute them without privilege, if they desired.

Fixes https://github.com/joyent/triton-docker-cli/issues/6

/cc @cheapRoc @tgross 