### PR TITLE
Inject extra env vars to make CNS usage easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ More about:
 - [Docker Compose on Triton](https://www.joyent.com/blog/using-docker-compose)
 - [Optimizing your Docker operations for Triton](https://www.joyent.com/blog/optimizing-docker-on-triton)
 
+### Triton Container Name Service helpers
+
+This will also set some helpful environment variables for using [Triton Container Name Service (CNS)](https://docs.joyent.com/public-cloud/network/cns):
+
+- `TRITON_CNS_SEARCH_DOMAIN_PUBLIC`
+- `TRITON_CNS_SEARCH_DOMAIN_PRIVATE`
+
+Those vars will be automatically set with values appropriate for use in Triton Public Cloud:
+
+```
+TRITON_CNS_SEARCH_DOMAIN_PRIVATE=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.cns.joyent.com
+TRITON_CNS_SEARCH_DOMAIN_PUBLIC=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.triton.zone
+```
+
+#### Notes and cautions
+
+- The mechanism that sets these environment vars only works for Triton Public Cloud. To use Triton Docker CLI with private cloud implementations of Triton, please set the `TRITON_CNS_SEARCH_DOMAIN_PUBLIC` and `TRITON_CNS_SEARCH_DOMAIN_PRIVATE` vars manually
+- These environment variables will be removed following the completion of CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898), which will automatically set the DNS search domain to these values
+- CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898) will also work on private cloud implementations of Triton, solving the problem for everybody
+
 ### Components
 
 In addition to the shell script in this repo, this script will install:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ TRITON_CNS_SEARCH_DOMAIN_PRIVATE=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.
 TRITON_CNS_SEARCH_DOMAIN_PUBLIC=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.triton.zone
 ```
 
-#### Notes and cautions
+#### Notes and cautions about CNS env vars
 
 - The mechanism that sets these environment vars only works for Triton Public Cloud. To use Triton Docker CLI with private cloud implementations of Triton, please set the `TRITON_CNS_SEARCH_DOMAIN_PUBLIC` and `TRITON_CNS_SEARCH_DOMAIN_PRIVATE` vars manually
 - These environment variables will be removed following the completion of CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898), which will automatically set the DNS search domain to these values

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ TRITON_CNS_SEARCH_DOMAIN_PUBLIC=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.t
 #### Notes and cautions about CNS env vars
 
 - The mechanism that sets these environment vars only works for Triton Public Cloud. To use Triton Docker CLI with private cloud implementations of Triton, please set the `TRITON_CNS_SEARCH_DOMAIN_PUBLIC` and `TRITON_CNS_SEARCH_DOMAIN_PRIVATE` vars manually
-- These environment variables will be removed following the completion of CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898), which will automatically set the DNS search domain to these values
-- CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898) will also work on private cloud implementations of Triton, solving the problem for everybody
+- These environment variables will be removed following the completion of [CNS-164](https://smartos.org/bugview/CNS-164) and [DOCKER-898](https://smartos.org/bugview/DOCKER-898), which will automatically set the DNS search domain to these values
+- [CNS-164](https://smartos.org/bugview/CNS-164) and [DOCKER-898](https://smartos.org/bugview/DOCKER-898) will also work on private cloud implementations of Triton, solving the problem for everybody
 
 ### Components
 

--- a/triton-docker
+++ b/triton-docker
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -e -o pipefail
 
 triton_docker_version=1.12.6
 triton_compose_version=1.9.0
@@ -71,21 +71,29 @@ function currentProfile () {
     echo "Executing in '$(triton profile get | awk 'NR == 1 {print $2}')' (${profile_source})"
 }
 
-# Extra env vars
-function extraEnvVars () {
+# Set env vars to make using CNS easier
+function CnsEnvVars () {
 
     # If the CNS env vars are already set, don't bother continuing
-    if [ -n "$TRITON_CNS_SUFFIX_PUBLIC" ] && [ -n "$TRITON_CNS_SUFFIX_PRIVATE" ]
+    if [ -n "$TRITON_CNS_SEARCH_DOMAIN_PUBLIC" ] && [ -n "$TRITON_CNS_SEARCH_DOMAIN_PRIVATE" ]
     then
         return
     fi
 
-    # Get and the user's account information for parsing later
+    # Get and the user's account information and CloudAPI URL for parsing later
     local triton_account="$(triton account get)"
+    local triton_url="$(triton profile get | awk -F"/" '/url:/{print $3}')"
+
+    # Do not continue if the target is not a Triton Public Cloud data center
+    if [ ! "api.joyent.com" == "$(echo "${triton_url}" | awk -F'.' '{print $2 "." $3 "." $4}')" ]
+    then
+        return
+    fi
 
     # Check if CNS is enabled, require it
-    local triton_cns_enabled="$(echo "$triton_account" | awk -F": " '/cns/{print $2}')"
-    if [ ! "true" == "$triton_cns_enabled" ]; then
+    local triton_cns_enabled="$(echo "${triton_account}" | awk -F": " '/cns/{print $2}')"
+    if [ ! "true" == "$triton_cns_enabled" ]
+    then
         echo
         tput rev  # reverse
         tput bold # bold
@@ -99,16 +107,16 @@ function extraEnvVars () {
     fi
 
     # Get the user's UUID
-    local triton_account_uuid="$(echo "$triton_account" | awk -F": " '/id:/{print $2}')"
+    local triton_account_uuid="$(echo "${triton_account}" | awk -F": " '/id:/{print $2}')"
 
     # Get current data center name
     # Note: this makes assumptions that work in our public cloud, but might not work elsewhere
     # Further note: set TRITON_CNS_SUFFIX_PUBLIC and TRITON_CNS_SUFFIX_PRIVATE to work around this
-    local triton_dc="$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')"
+    local triton_dc="$(echo "${triton_url}" | awk -F'.' '{print $1}')"
 
     # Set the CNS base for public and private names
-    export TRITON_CNS_SUFFIX_PUBLIC="${triton_account_uuid}.${triton_dc}.triton.zone"
-    export TRITON_CNS_SUFFIX_PRIVATE="${triton_account_uuid}.${triton_dc}.cns.joyent.com"
+    export TRITON_CNS_SEARCH_DOMAIN_PUBLIC="${triton_account_uuid}.${triton_dc}.triton.zone"
+    export TRITON_CNS_SEARCH_DOMAIN_PRIVATE="${triton_account_uuid}.${triton_dc}.cns.joyent.com"
 }
 
 # Run all checks
@@ -129,14 +137,14 @@ case "$(basename $0)" in
     triton-docker)
         checkAll &&
         eval "$(triton env)" &&
-        extraEnvVars &&
+        CnsEnvVars &&
         exec /usr/local/bin/triton-docker-helper $@
         ;;
     triton-compose)
         checkAll &&
         eval "$(triton env)" &&
         export COMPOSE_HTTP_TIMEOUT=750 &&
-        extraEnvVars &&
+        CnsEnvVars &&
         exec /usr/local/bin/triton-compose-helper $@
         ;;
     triton-docker-install)

--- a/triton-docker
+++ b/triton-docker
@@ -14,18 +14,6 @@ function checkCurlInstalled () {
     command -v curl >/dev/null 2>&1 || { echo >&2 "curl is required to complete this installation. Please install before continuing."; exit 1; }
 }
 
-# Emit the current Triton profile and time
-function currentProfile () {
-    if [ -n "$TRITON_PROFILE" ]
-    then
-        local profile_source='via env var; use `eval "$(triton env <profile name>)"` to change'
-    else
-        local profile_source='default; use `triton profile set <profile name>` to change'
-    fi
-
-    echo "Executing in '$(triton profile get | awk 'NR == 1 {print $2}')' (${profile_source})"
-}
-
 # Check if the Docker binary (named triton-docker-helper)
 # and Docker Compose (named triton-compose-helper) are installed and executable
 function checkDockerInstalled () {
@@ -71,6 +59,52 @@ function install () {
     echo
 }
 
+# Emit the current Triton profile and time
+function currentProfile () {
+    if [ -n "$TRITON_PROFILE" ]
+    then
+        local profile_source='via env var; use `eval "$(triton env <profile name>)"` to change'
+    else
+        local profile_source='default; use `triton profile set <profile name>` to change'
+    fi
+
+    echo "Executing in '$(triton profile get | awk 'NR == 1 {print $2}')' (${profile_source})"
+}
+
+# Extra env vars
+function extraEnvVars () {
+
+    # Get the user's UUID and current data center name
+    local triton_account="$(triton account get)"
+    export TRITON_ACCOUNT_UUID="$(echo "$triton_account" | awk -F": " '/id:/{print $2}')"
+    export TRITON_DC="$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')"
+
+    # Set the CNS base for public and private names
+    if [ ! -n "$TRITON_CNS_SUFFIX_PUBLIC" ]
+    then
+        export TRITON_CNS_SUFFIX_PUBLIC="${TRITON_ACCOUNT}.${TRITON_DC}.triton.zone"
+    fi
+    if [ ! -n "$TRITON_CNS_SUFFIX_PRIVATE" ]
+    then
+        export TRITON_CNS_SUFFIX_PRIVATE="${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com"
+    fi
+
+    # Check if CNS is enabled, require it
+    local triton_cns_enabled="$(echo "$triton_account" | awk -F": " '/cns/{print $2}')"
+    if [ ! "true" == "$triton_cns_enabled" ]; then
+        echo
+        tput rev  # reverse
+        tput bold # bold
+        echo 'Error! Triton CNS is required and not enabled.'
+        tput sgr0 # clear
+        echo
+        echo 'Please run:'
+        echo '  triton account update triton_cns_enabled=true'
+        echo
+        exit 1
+    fi
+}
+
 # Run all checks
 function checkAll () {
     checkTritonInstalled &&
@@ -89,12 +123,14 @@ case "$(basename $0)" in
     triton-docker)
         checkAll &&
         eval "$(triton env)" &&
+        extraEnvVars &&
         exec /usr/local/bin/triton-docker-helper $@
         ;;
     triton-compose)
         checkAll &&
         eval "$(triton env)" &&
         export COMPOSE_HTTP_TIMEOUT=750 &&
+        extraEnvVars &&
         exec /usr/local/bin/triton-compose-helper $@
         ;;
     triton-docker-install)

--- a/triton-docker
+++ b/triton-docker
@@ -74,20 +74,14 @@ function currentProfile () {
 # Extra env vars
 function extraEnvVars () {
 
-    # Get the user's UUID and current data center name
-    local triton_account="$(triton account get)"
-    export TRITON_ACCOUNT_UUID="$(echo "$triton_account" | awk -F": " '/id:/{print $2}')"
-    export TRITON_DC="$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')"
+    # If the CNS env vars are already set, don't bother continuing
+    if [ -n "$TRITON_CNS_SUFFIX_PUBLIC" ] && [ -n "$TRITON_CNS_SUFFIX_PRIVATE" ]
+    then
+        return
+    fi
 
-    # Set the CNS base for public and private names
-    if [ ! -n "$TRITON_CNS_SUFFIX_PUBLIC" ]
-    then
-        export TRITON_CNS_SUFFIX_PUBLIC="${TRITON_ACCOUNT}.${TRITON_DC}.triton.zone"
-    fi
-    if [ ! -n "$TRITON_CNS_SUFFIX_PRIVATE" ]
-    then
-        export TRITON_CNS_SUFFIX_PRIVATE="${TRITON_ACCOUNT}.${TRITON_DC}.cns.joyent.com"
-    fi
+    # Get and the user's account information for parsing later
+    local triton_account="$(triton account get)"
 
     # Check if CNS is enabled, require it
     local triton_cns_enabled="$(echo "$triton_account" | awk -F": " '/cns/{print $2}')"
@@ -103,6 +97,18 @@ function extraEnvVars () {
         echo
         exit 1
     fi
+
+    # Get the user's UUID
+    local triton_account_uuid="$(echo "$triton_account" | awk -F": " '/id:/{print $2}')"
+
+    # Get current data center name
+    # Note: this makes assumptions that work in our public cloud, but might not work elsewhere
+    # Further note: set TRITON_CNS_SUFFIX_PUBLIC and TRITON_CNS_SUFFIX_PRIVATE to work around this
+    local triton_dc="$(triton profile get | awk -F"/" '/url:/{print $3}' | awk -F'.' '{print $1}')"
+
+    # Set the CNS base for public and private names
+    export TRITON_CNS_SUFFIX_PUBLIC="${triton_account_uuid}.${triton_dc}.triton.zone"
+    export TRITON_CNS_SUFFIX_PRIVATE="${triton_account_uuid}.${triton_dc}.cns.joyent.com"
 }
 
 # Run all checks


### PR DESCRIPTION
When connected to Triton Public Cloud, this change:

- Checks that CNS is enabled
- Sets env vars to use as the DNS search domain based on the CNS suffixes

The resulting env vars look like:

```
TRITON_CNS_SEARCH_DOMAIN_PRIVATE=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.cns.joyent.com
TRITON_CNS_SEARCH_DOMAIN_PUBLIC=a42e7881-89d2-459e-bc0b-e9af0bca409a.us-east-3.triton.zone
```

If those env vars are set in the user's environment prior to invoking this script, it will not attempt to overwrite them.

This only works for Triton Public Cloud installs, and it's really only a work around until CNS-164 and [DOCKER-898](https://smartos.org/bugview/DOCKER-898) are complete. Once those are complete, these env vars will be removed and users should depend instead on the search domain set in the instance.

Fixes https://github.com/joyent/triton-docker-cli/issues/5

/cc @tgross @trentm 